### PR TITLE
Edit manifest tab

### DIFF
--- a/godot-mod-export-tool-plugin/godot-3/addons/godot-mod-export/dock.gd
+++ b/godot-mod-export-tool-plugin/godot-3/addons/godot-mod-export/dock.gd
@@ -3,7 +3,6 @@ extends Control
 
 onready var label_output = $"%Output"
 
-
 var base_theme: Theme 	# passed from the EditorPlugin
 onready var tab_parent_bottom_panel: PanelContainer
 
@@ -12,6 +11,39 @@ func _ready() -> void:
 	tab_parent_bottom_panel = get_parent().get_parent() as PanelContainer
 	if base_theme:
 		$TabContainer.add_stylebox_override("panel", base_theme.get_stylebox("DebuggerPanel", "EditorStyles"))
+
+	# set up warning icons to show if a field is invalid
+	for node in $"TabContainer/Mod Manifest/ScrollContainer/VBox".get_children():
+		if node.has_method("set_error_icon"):
+			node.set_error_icon(base_theme.get_icon("NodeWarning", "EditorIcons"))
+
+	_load_manifest()
+	_is_manifest_valid()
+
+
+func _save_manifest() -> void:
+	pass # todo
+
+
+func _load_manifest() -> void:
+	pass # todo
+
+
+func _is_manifest_valid() -> bool:
+	var mod_manifest: Script
+	if File.new().file_exists("res://addons/mod_loader/mod_manifest.gd"):
+		mod_manifest = load("res://addons/mod_loader/mod_manifest.gd")
+
+	var is_valid: bool
+	if not mod_manifest:
+		return false
+
+	var mod_name: String = $"%ModName".get_value()
+	is_valid = $"%ModName".show_error_if_not(mod_manifest.is_name_or_namespace_valid(mod_name))
+
+	# todo
+
+	return is_valid
 
 
 func _run_command(command: String, is_ui_visible = false):
@@ -24,16 +56,29 @@ func _run_command(command: String, is_ui_visible = false):
 		label_output.text = str(label_output.text, '\n', text)
 
 
-func _on_btn_run_game_pressed():
+func _on_export_and_run_pressed() -> void:
 	_run_command("--run")
 
 
-func _on_btn_build_pressed():
+func _on_export_pressed() -> void:
 	_run_command("--build")
 
 
-func _on_btn_ui_pressed():
-	_run_command("", true)
+func _on_clear_output_pressed() -> void:
+	pass # todo
+
+
+func _on_copy_output_pressed() -> void:
+	pass # todo
+
+
+func _on_save_manifest_pressed() -> void:
+	if _is_manifest_valid():
+		_save_manifest()
+
+
+func _on_mod_skeleton_pressed() -> void:
+	pass # todo
 
 
 # replicates the behaviour for the debugger tab styles
@@ -41,7 +86,7 @@ func _on_btn_ui_pressed():
 # full rect Control and have a margin_left of -10 and a margin_right of 10
 # this is to offset the 10px content margins that are still present in the
 # BottomPanelDebuggerOverride stylebox for some reason. It's how Godot does it.
-func _on_ModToolsDock_visibility_changed() -> void:
+func _on_mod_tools_dock_visibility_changed() -> void:
 	if not visible or not base_theme or not tab_parent_bottom_panel:
 		return
 

--- a/godot-mod-export-tool-plugin/godot-3/addons/godot-mod-export/dock.gd
+++ b/godot-mod-export-tool-plugin/godot-3/addons/godot-mod-export/dock.gd
@@ -4,6 +4,14 @@ extends Control
 onready var label_output = $"%Output"
 
 
+var base_theme: Theme 	# passed from the EditorPlugin
+onready var tab_parent_bottom_panel: PanelContainer
+
+
+func _ready() -> void:
+	tab_parent_bottom_panel = get_parent().get_parent() as PanelContainer
+	if base_theme:
+		$TabContainer.add_stylebox_override("panel", base_theme.get_stylebox("DebuggerPanel", "EditorStyles"))
 
 
 func _run_command(command: String, is_ui_visible = false):
@@ -26,3 +34,22 @@ func _on_btn_build_pressed():
 
 func _on_btn_ui_pressed():
 	_run_command("", true)
+
+
+# replicates the behaviour for the debugger tab styles
+# for the full setup of this, the TabContainer needs to be the child of a
+# full rect Control and have a margin_left of -10 and a margin_right of 10
+# this is to offset the 10px content margins that are still present in the
+# BottomPanelDebuggerOverride stylebox for some reason. It's how Godot does it.
+func _on_ModToolsDock_visibility_changed() -> void:
+	if not visible or not base_theme or not tab_parent_bottom_panel:
+		return
+
+	# the panel style is overridden by godot after this method is called
+	# make sure our override-override is applied after that
+	yield(get_tree(), "idle_frame")
+
+	var panel_box: StyleBoxFlat = base_theme.get_stylebox("BottomPanelDebuggerOverride", "EditorStyles")
+	tab_parent_bottom_panel.add_stylebox_override("panel", panel_box)
+
+

--- a/godot-mod-export-tool-plugin/godot-3/addons/godot-mod-export/dock.tscn
+++ b/godot-mod-export-tool-plugin/godot-3/addons/godot-mod-export/dock.tscn
@@ -29,15 +29,20 @@ __meta__ = {
 "original": SubResource( 3 )
 }
 
-[node name="TabContainer" type="TabContainer"]
+[node name="ModToolsDock" type="Control"]
 anchor_right = 1.0
 anchor_bottom = 1.0
 rect_min_size = Vector2( 0, 400 )
-tab_align = 0
 script = ExtResource( 1 )
-text = "hello"
 
-[node name="Export" type="PanelContainer" parent="."]
+[node name="TabContainer" type="TabContainer" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_left = -10.0
+margin_right = 10.0
+tab_align = 0
+
+[node name="Export" type="PanelContainer" parent="TabContainer"]
 anchor_right = 1.0
 anchor_bottom = 1.0
 margin_left = 4.0
@@ -45,49 +50,49 @@ margin_top = 32.0
 margin_right = -4.0
 margin_bottom = -4.0
 
-[node name="HSplit" type="HSplitContainer" parent="Export"]
+[node name="HSplit" type="HSplitContainer" parent="TabContainer/Export"]
 margin_left = 7.0
 margin_top = 7.0
-margin_right = 1905.0
+margin_right = 1925.0
 margin_bottom = 1037.0
 
-[node name="Console" type="VBoxContainer" parent="Export/HSplit"]
-margin_right = 1259.0
+[node name="Console" type="VBoxContainer" parent="TabContainer/Export/HSplit"]
+margin_right = 1272.0
 margin_bottom = 1030.0
 rect_pivot_offset = Vector2( -230, -400 )
 size_flags_horizontal = 3
 
-[node name="HBox" type="HBoxContainer" parent="Export/HSplit/Console"]
-margin_right = 1259.0
+[node name="HBox" type="HBoxContainer" parent="TabContainer/Export/HSplit/Console"]
+margin_right = 1272.0
 margin_bottom = 20.0
 
-[node name="Label" type="Label" parent="Export/HSplit/Console/HBox"]
+[node name="Label" type="Label" parent="TabContainer/Export/HSplit/Console/HBox"]
 margin_top = 3.0
-margin_right = 1164.0
+margin_right = 1177.0
 margin_bottom = 17.0
 size_flags_horizontal = 3
 text = "Output:"
 
-[node name="CopyOutput" type="Button" parent="Export/HSplit/Console/HBox"]
+[node name="CopyOutput" type="Button" parent="TabContainer/Export/HSplit/Console/HBox"]
 unique_name_in_owner = true
-margin_left = 1168.0
-margin_right = 1211.0
+margin_left = 1181.0
+margin_right = 1224.0
 margin_bottom = 20.0
 shortcut = SubResource( 12 )
 text = "Copy"
 
-[node name="ClearOutput" type="Button" parent="Export/HSplit/Console/HBox"]
+[node name="ClearOutput" type="Button" parent="TabContainer/Export/HSplit/Console/HBox"]
 unique_name_in_owner = true
-margin_left = 1215.0
-margin_right = 1259.0
+margin_left = 1228.0
+margin_right = 1272.0
 margin_bottom = 20.0
 shortcut = SubResource( 13 )
 text = "Clear"
 
-[node name="Output" type="RichTextLabel" parent="Export/HSplit/Console"]
+[node name="Output" type="RichTextLabel" parent="TabContainer/Export/HSplit/Console"]
 unique_name_in_owner = true
 margin_top = 24.0
-margin_right = 1259.0
+margin_right = 1272.0
 margin_bottom = 1030.0
 focus_mode = 2
 size_flags_vertical = 3
@@ -95,131 +100,131 @@ bbcode_enabled = true
 scroll_following = true
 selection_enabled = true
 
-[node name="Buttons" type="VBoxContainer" parent="Export/HSplit"]
-margin_left = 1271.0
-margin_right = 1898.0
+[node name="Buttons" type="VBoxContainer" parent="TabContainer/Export/HSplit"]
+margin_left = 1284.0
+margin_right = 1918.0
 margin_bottom = 1030.0
 rect_min_size = Vector2( 300, 0 )
 rect_pivot_offset = Vector2( -1685, 180 )
 size_flags_horizontal = 3
 size_flags_stretch_ratio = 0.5
 
-[node name="Label" type="Label" parent="Export/HSplit/Buttons"]
-margin_right = 627.0
+[node name="Label" type="Label" parent="TabContainer/Export/HSplit/Buttons"]
+margin_right = 634.0
 margin_bottom = 14.0
 text = "Export Settings"
 align = 1
 
-[node name="ScrollContainer" type="ScrollContainer" parent="Export/HSplit/Buttons"]
+[node name="ScrollContainer" type="ScrollContainer" parent="TabContainer/Export/HSplit/Buttons"]
 margin_top = 18.0
-margin_right = 627.0
+margin_right = 634.0
 margin_bottom = 944.0
 size_flags_vertical = 3
 scroll_horizontal_enabled = false
 
-[node name="VBoxContainer" type="VBoxContainer" parent="Export/HSplit/Buttons/ScrollContainer"]
-margin_right = 627.0
+[node name="VBoxContainer" type="VBoxContainer" parent="TabContainer/Export/HSplit/Buttons/ScrollContainer"]
+margin_right = 634.0
 margin_bottom = 80.0
 size_flags_horizontal = 3
 
-[node name="HBoxContainer" type="HBoxContainer" parent="Export/HSplit/Buttons/ScrollContainer/VBoxContainer"]
-margin_right = 627.0
+[node name="HBoxContainer" type="HBoxContainer" parent="TabContainer/Export/HSplit/Buttons/ScrollContainer/VBoxContainer"]
+margin_right = 634.0
 margin_bottom = 24.0
 hint_tooltip = "ID of the mod to be exported.
 Format: Namespace-ModName
 (Often Author-ModName)"
 
-[node name="Label" type="Label" parent="Export/HSplit/Buttons/ScrollContainer/VBoxContainer/HBoxContainer"]
+[node name="Label" type="Label" parent="TabContainer/Export/HSplit/Buttons/ScrollContainer/VBoxContainer/HBoxContainer"]
 margin_top = 5.0
-margin_right = 311.0
+margin_right = 315.0
 margin_bottom = 19.0
 size_flags_horizontal = 3
 text = "Mod ID"
 clip_text = true
 
-[node name="ModId" type="LineEdit" parent="Export/HSplit/Buttons/ScrollContainer/VBoxContainer/HBoxContainer"]
+[node name="ModId" type="LineEdit" parent="TabContainer/Export/HSplit/Buttons/ScrollContainer/VBoxContainer/HBoxContainer"]
 unique_name_in_owner = true
-margin_left = 315.0
-margin_right = 627.0
+margin_left = 319.0
+margin_right = 634.0
 margin_bottom = 24.0
 size_flags_horizontal = 3
-placeholder_text = "Author-Name"
+placeholder_text = "Author-ModName"
 
-[node name="HBoxContainer3" type="HBoxContainer" parent="Export/HSplit/Buttons/ScrollContainer/VBoxContainer"]
+[node name="HBoxContainer3" type="HBoxContainer" parent="TabContainer/Export/HSplit/Buttons/ScrollContainer/VBoxContainer"]
 margin_top = 28.0
-margin_right = 627.0
+margin_right = 634.0
 margin_bottom = 52.0
 
-[node name="Label" type="Label" parent="Export/HSplit/Buttons/ScrollContainer/VBoxContainer/HBoxContainer3"]
+[node name="Label" type="Label" parent="TabContainer/Export/HSplit/Buttons/ScrollContainer/VBoxContainer/HBoxContainer3"]
 margin_top = 5.0
-margin_right = 311.0
+margin_right = 315.0
 margin_bottom = 19.0
 size_flags_horizontal = 3
 text = "Export Path"
 clip_text = true
 
-[node name="ExportPath" type="LineEdit" parent="Export/HSplit/Buttons/ScrollContainer/VBoxContainer/HBoxContainer3"]
+[node name="ExportPath" type="LineEdit" parent="TabContainer/Export/HSplit/Buttons/ScrollContainer/VBoxContainer/HBoxContainer3"]
 unique_name_in_owner = true
-margin_left = 315.0
-margin_right = 627.0
+margin_left = 319.0
+margin_right = 634.0
 margin_bottom = 24.0
 size_flags_horizontal = 3
 text = "res://zips"
 
-[node name="HBoxContainer4" type="HBoxContainer" parent="Export/HSplit/Buttons/ScrollContainer/VBoxContainer"]
+[node name="HBoxContainer4" type="HBoxContainer" parent="TabContainer/Export/HSplit/Buttons/ScrollContainer/VBoxContainer"]
 margin_top = 56.0
-margin_right = 627.0
+margin_right = 634.0
 margin_bottom = 80.0
 hint_tooltip = "Modify the zip before compressing 
 to follow Thunderstore specifications"
 
-[node name="Label" type="Label" parent="Export/HSplit/Buttons/ScrollContainer/VBoxContainer/HBoxContainer4"]
+[node name="Label" type="Label" parent="TabContainer/Export/HSplit/Buttons/ScrollContainer/VBoxContainer/HBoxContainer4"]
 margin_top = 5.0
-margin_right = 311.0
+margin_right = 315.0
 margin_bottom = 19.0
 size_flags_horizontal = 3
 text = "Thunderstore Export"
 clip_text = true
 
-[node name="CheckBox" type="CheckBox" parent="Export/HSplit/Buttons/ScrollContainer/VBoxContainer/HBoxContainer4"]
-margin_left = 315.0
-margin_right = 627.0
+[node name="CheckBox" type="CheckBox" parent="TabContainer/Export/HSplit/Buttons/ScrollContainer/VBoxContainer/HBoxContainer4"]
+margin_left = 319.0
+margin_right = 634.0
 margin_bottom = 24.0
 size_flags_horizontal = 3
 text = "On"
 
-[node name="PanelContainer" type="PanelContainer" parent="Export/HSplit/Buttons"]
+[node name="PanelContainer" type="PanelContainer" parent="TabContainer/Export/HSplit/Buttons"]
 margin_top = 948.0
-margin_right = 627.0
+margin_right = 634.0
 margin_bottom = 1030.0
 
-[node name="VBoxContainer" type="VBoxContainer" parent="Export/HSplit/Buttons/PanelContainer"]
+[node name="VBoxContainer" type="VBoxContainer" parent="TabContainer/Export/HSplit/Buttons/PanelContainer"]
 margin_left = 7.0
 margin_top = 7.0
-margin_right = 620.0
+margin_right = 627.0
 margin_bottom = 75.0
 
-[node name="ExportRun" type="Button" parent="Export/HSplit/Buttons/PanelContainer/VBoxContainer"]
+[node name="ExportRun" type="Button" parent="TabContainer/Export/HSplit/Buttons/PanelContainer/VBoxContainer"]
 unique_name_in_owner = true
-margin_right = 613.0
+margin_right = 620.0
 margin_bottom = 20.0
 text = "Export Mod & Run Game"
 
-[node name="Export" type="Button" parent="Export/HSplit/Buttons/PanelContainer/VBoxContainer"]
+[node name="Export" type="Button" parent="TabContainer/Export/HSplit/Buttons/PanelContainer/VBoxContainer"]
 unique_name_in_owner = true
 margin_top = 24.0
-margin_right = 613.0
+margin_right = 620.0
 margin_bottom = 44.0
 text = "Export Mod"
 
-[node name="ModSkeleton" type="Button" parent="Export/HSplit/Buttons/PanelContainer/VBoxContainer"]
+[node name="ModSkeleton" type="Button" parent="TabContainer/Export/HSplit/Buttons/PanelContainer/VBoxContainer"]
 unique_name_in_owner = true
 margin_top = 48.0
-margin_right = 613.0
+margin_right = 620.0
 margin_bottom = 68.0
 text = "Generate Mod Skeleton"
 
-[node name="Mod Manifest" type="PanelContainer" parent="."]
+[node name="Mod Manifest" type="PanelContainer" parent="TabContainer"]
 visible = false
 anchor_right = 1.0
 anchor_bottom = 1.0
@@ -228,7 +233,9 @@ margin_top = 32.0
 margin_right = -4.0
 margin_bottom = -4.0
 
-[node name="Default Configuration" type="PanelContainer" parent="."]
+[node name="Default Configuration" type="PanelContainer" parent="TabContainer"]
 visible = false
 margin_right = 40.0
 margin_bottom = 24.0
+
+[connection signal="visibility_changed" from="." to="." method="_on_ModToolsDock_visibility_changed"]

--- a/godot-mod-export-tool-plugin/godot-3/addons/godot-mod-export/dock.tscn
+++ b/godot-mod-export-tool-plugin/godot-3/addons/godot-mod-export/dock.tscn
@@ -1,6 +1,8 @@
-[gd_scene load_steps=6 format=2]
+[gd_scene load_steps=8 format=2]
 
 [ext_resource path="res://addons/godot-mod-export/dock.gd" type="Script" id=1]
+[ext_resource path="res://addons/godot-mod-export/input_string.tscn" type="PackedScene" id=3]
+[ext_resource path="res://addons/godot-mod-export/input_string_multiline.tscn" type="PackedScene" id=4]
 
 [sub_resource type="InputEventKey" id=1]
 meta = true
@@ -74,7 +76,6 @@ size_flags_horizontal = 3
 text = "Output:"
 
 [node name="CopyOutput" type="Button" parent="TabContainer/Export/HSplit/Console/HBox"]
-unique_name_in_owner = true
 margin_left = 1181.0
 margin_right = 1224.0
 margin_bottom = 20.0
@@ -82,7 +83,6 @@ shortcut = SubResource( 12 )
 text = "Copy"
 
 [node name="ClearOutput" type="Button" parent="TabContainer/Export/HSplit/Console/HBox"]
-unique_name_in_owner = true
 margin_left = 1228.0
 margin_right = 1272.0
 margin_bottom = 20.0
@@ -100,7 +100,7 @@ bbcode_enabled = true
 scroll_following = true
 selection_enabled = true
 
-[node name="Buttons" type="VBoxContainer" parent="TabContainer/Export/HSplit"]
+[node name="Settings" type="VBoxContainer" parent="TabContainer/Export/HSplit"]
 margin_left = 1284.0
 margin_right = 1918.0
 margin_bottom = 1030.0
@@ -109,76 +109,64 @@ rect_pivot_offset = Vector2( -1685, 180 )
 size_flags_horizontal = 3
 size_flags_stretch_ratio = 0.5
 
-[node name="Label" type="Label" parent="TabContainer/Export/HSplit/Buttons"]
+[node name="Label" type="Label" parent="TabContainer/Export/HSplit/Settings"]
 margin_right = 634.0
 margin_bottom = 14.0
 text = "Export Settings"
 align = 1
 
-[node name="ScrollContainer" type="ScrollContainer" parent="TabContainer/Export/HSplit/Buttons"]
+[node name="Scroll" type="ScrollContainer" parent="TabContainer/Export/HSplit/Settings"]
 margin_top = 18.0
 margin_right = 634.0
 margin_bottom = 944.0
 size_flags_vertical = 3
 scroll_horizontal_enabled = false
 
-[node name="VBoxContainer" type="VBoxContainer" parent="TabContainer/Export/HSplit/Buttons/ScrollContainer"]
+[node name="VBox" type="VBoxContainer" parent="TabContainer/Export/HSplit/Settings/Scroll"]
 margin_right = 634.0
 margin_bottom = 80.0
 size_flags_horizontal = 3
 
-[node name="HBoxContainer" type="HBoxContainer" parent="TabContainer/Export/HSplit/Buttons/ScrollContainer/VBoxContainer"]
+[node name="ModId" parent="TabContainer/Export/HSplit/Settings/Scroll/VBox" instance=ExtResource( 3 )]
+unique_name_in_owner = true
+anchor_right = 0.0
 margin_right = 634.0
-margin_bottom = 24.0
 hint_tooltip = "ID of the mod to be exported.
 Format: Namespace-ModName
 (Often Author-ModName)"
+mouse_default_cursor_shape = 16
+is_required = true
+label_text = "Mod ID"
+input_placeholder = "Author-ModName"
+hint_text = "ID of the mod to be exported.
+Format: Namespace-ModName
+(Often Author-ModName)"
 
-[node name="Label" type="Label" parent="TabContainer/Export/HSplit/Buttons/ScrollContainer/VBoxContainer/HBoxContainer"]
-margin_top = 5.0
-margin_right = 315.0
-margin_bottom = 19.0
-size_flags_horizontal = 3
-text = "Mod ID"
-clip_text = true
-
-[node name="ModId" type="LineEdit" parent="TabContainer/Export/HSplit/Buttons/ScrollContainer/VBoxContainer/HBoxContainer"]
+[node name="ExportPath" parent="TabContainer/Export/HSplit/Settings/Scroll/VBox" instance=ExtResource( 3 )]
 unique_name_in_owner = true
-margin_left = 319.0
-margin_right = 634.0
-margin_bottom = 24.0
-size_flags_horizontal = 3
-placeholder_text = "Author-ModName"
-
-[node name="HBoxContainer3" type="HBoxContainer" parent="TabContainer/Export/HSplit/Buttons/ScrollContainer/VBoxContainer"]
+anchor_right = 0.0
 margin_top = 28.0
 margin_right = 634.0
 margin_bottom = 52.0
+hint_tooltip = "ID of the mod to be exported.
+Format: Namespace-ModName
+(Often Author-ModName)"
+mouse_default_cursor_shape = 16
+label_text = "Export Path"
+input_text = "res://zips"
+input_placeholder = "Author-ModName"
+hint_text = "ID of the mod to be exported.
+Format: Namespace-ModName
+(Often Author-ModName)"
 
-[node name="Label" type="Label" parent="TabContainer/Export/HSplit/Buttons/ScrollContainer/VBoxContainer/HBoxContainer3"]
-margin_top = 5.0
-margin_right = 315.0
-margin_bottom = 19.0
-size_flags_horizontal = 3
-text = "Export Path"
-clip_text = true
-
-[node name="ExportPath" type="LineEdit" parent="TabContainer/Export/HSplit/Buttons/ScrollContainer/VBoxContainer/HBoxContainer3"]
-unique_name_in_owner = true
-margin_left = 319.0
-margin_right = 634.0
-margin_bottom = 24.0
-size_flags_horizontal = 3
-text = "res://zips"
-
-[node name="HBoxContainer4" type="HBoxContainer" parent="TabContainer/Export/HSplit/Buttons/ScrollContainer/VBoxContainer"]
+[node name="HBox" type="HBoxContainer" parent="TabContainer/Export/HSplit/Settings/Scroll/VBox"]
 margin_top = 56.0
 margin_right = 634.0
 margin_bottom = 80.0
 hint_tooltip = "Modify the zip before compressing 
 to follow Thunderstore specifications"
 
-[node name="Label" type="Label" parent="TabContainer/Export/HSplit/Buttons/ScrollContainer/VBoxContainer/HBoxContainer4"]
+[node name="Label" type="Label" parent="TabContainer/Export/HSplit/Settings/Scroll/VBox/HBox"]
 margin_top = 5.0
 margin_right = 315.0
 margin_bottom = 19.0
@@ -186,39 +174,37 @@ size_flags_horizontal = 3
 text = "Thunderstore Export"
 clip_text = true
 
-[node name="CheckBox" type="CheckBox" parent="TabContainer/Export/HSplit/Buttons/ScrollContainer/VBoxContainer/HBoxContainer4"]
+[node name="ThunderstoreExport" type="CheckBox" parent="TabContainer/Export/HSplit/Settings/Scroll/VBox/HBox"]
+unique_name_in_owner = true
 margin_left = 319.0
 margin_right = 634.0
 margin_bottom = 24.0
 size_flags_horizontal = 3
 text = "On"
 
-[node name="PanelContainer" type="PanelContainer" parent="TabContainer/Export/HSplit/Buttons"]
+[node name="Buttons" type="PanelContainer" parent="TabContainer/Export/HSplit/Settings"]
 margin_top = 948.0
 margin_right = 634.0
 margin_bottom = 1030.0
 
-[node name="VBoxContainer" type="VBoxContainer" parent="TabContainer/Export/HSplit/Buttons/PanelContainer"]
+[node name="VBox" type="VBoxContainer" parent="TabContainer/Export/HSplit/Settings/Buttons"]
 margin_left = 7.0
 margin_top = 7.0
 margin_right = 627.0
 margin_bottom = 75.0
 
-[node name="ExportRun" type="Button" parent="TabContainer/Export/HSplit/Buttons/PanelContainer/VBoxContainer"]
-unique_name_in_owner = true
+[node name="ExportAndRun" type="Button" parent="TabContainer/Export/HSplit/Settings/Buttons/VBox"]
 margin_right = 620.0
 margin_bottom = 20.0
 text = "Export Mod & Run Game"
 
-[node name="Export" type="Button" parent="TabContainer/Export/HSplit/Buttons/PanelContainer/VBoxContainer"]
-unique_name_in_owner = true
+[node name="Export" type="Button" parent="TabContainer/Export/HSplit/Settings/Buttons/VBox"]
 margin_top = 24.0
 margin_right = 620.0
 margin_bottom = 44.0
 text = "Export Mod"
 
-[node name="ModSkeleton" type="Button" parent="TabContainer/Export/HSplit/Buttons/PanelContainer/VBoxContainer"]
-unique_name_in_owner = true
+[node name="ModSkeleton" type="Button" parent="TabContainer/Export/HSplit/Settings/Buttons/VBox"]
 margin_top = 48.0
 margin_right = 620.0
 margin_bottom = 68.0
@@ -233,9 +219,232 @@ margin_top = 32.0
 margin_right = -4.0
 margin_bottom = -4.0
 
+[node name="ScrollContainer" type="ScrollContainer" parent="TabContainer/Mod Manifest"]
+margin_left = 7.0
+margin_top = 7.0
+margin_right = 1925.0
+margin_bottom = 1037.0
+size_flags_vertical = 3
+follow_focus = true
+scroll_horizontal_enabled = false
+
+[node name="VBox" type="VBoxContainer" parent="TabContainer/Mod Manifest/ScrollContainer"]
+margin_right = 1918.0
+margin_bottom = 572.0
+size_flags_horizontal = 3
+__meta__ = {
+"_editor_description_": ""
+}
+
+[node name="Category" type="LineEdit" parent="TabContainer/Mod Manifest/ScrollContainer/VBox"]
+margin_right = 1918.0
+margin_bottom = 24.0
+mouse_filter = 2
+mouse_default_cursor_shape = 0
+text = "Manifest"
+align = 1
+editable = false
+context_menu_enabled = false
+virtual_keyboard_enabled = false
+shortcut_keys_enabled = false
+middle_mouse_paste_enabled = false
+
+[node name="HBoxContainer" type="HBoxContainer" parent="TabContainer/Mod Manifest/ScrollContainer/VBox"]
+margin_top = 28.0
+margin_right = 1918.0
+margin_bottom = 48.0
+
+[node name="Control" type="Control" parent="TabContainer/Mod Manifest/ScrollContainer/VBox/HBoxContainer"]
+margin_right = 1765.0
+margin_bottom = 20.0
+size_flags_horizontal = 3
+
+[node name="SaveManifest" type="Button" parent="TabContainer/Mod Manifest/ScrollContainer/VBox/HBoxContainer"]
+margin_left = 1769.0
+margin_right = 1918.0
+margin_bottom = 20.0
+text = "Save to manifest.json"
+
+[node name="ModName" parent="TabContainer/Mod Manifest/ScrollContainer/VBox" instance=ExtResource( 3 )]
+unique_name_in_owner = true
+anchor_right = 0.0
+margin_top = 52.0
+margin_right = 1918.0
+margin_bottom = 76.0
+hint_tooltip = "Name of the Mod.
+Only letters, numbers and underscores allowed."
+mouse_default_cursor_shape = 16
+is_required = true
+label_text = "Mod Name"
+hint_text = "Name of the Mod.
+Only letters, numbers and underscores allowed."
+
+[node name="Namespace" parent="TabContainer/Mod Manifest/ScrollContainer/VBox" instance=ExtResource( 3 )]
+unique_name_in_owner = true
+anchor_right = 0.0
+margin_top = 80.0
+margin_right = 1918.0
+margin_bottom = 104.0
+hint_tooltip = "Namespace of the Mod.
+Often just the main author or team name.
+Only letters, numbers and underscores allowed."
+mouse_default_cursor_shape = 16
+is_required = true
+label_text = "Namespace"
+hint_text = "Namespace of the Mod.
+Often just the main author or team name.
+Only letters, numbers and underscores allowed."
+
+[node name="Version" parent="TabContainer/Mod Manifest/ScrollContainer/VBox" instance=ExtResource( 3 )]
+unique_name_in_owner = true
+anchor_right = 0.0
+margin_top = 108.0
+margin_right = 1918.0
+margin_bottom = 132.0
+hint_tooltip = "Semantic version string.
+Only integers and periods allowed.
+Format: {major}.{minor}.{patch}
+For reference, see https://semver.org"
+mouse_default_cursor_shape = 16
+is_required = true
+label_text = "Version"
+input_text = "0.0.1"
+hint_text = "Semantic version string.
+Only integers and periods allowed.
+Format: {major}.{minor}.{patch}
+For reference, see https://semver.org"
+
+[node name="WebsiteUrl" parent="TabContainer/Mod Manifest/ScrollContainer/VBox" instance=ExtResource( 3 )]
+unique_name_in_owner = true
+anchor_right = 0.0
+margin_top = 136.0
+margin_right = 1918.0
+margin_bottom = 160.0
+hint_tooltip = "URL for your website or repository."
+mouse_default_cursor_shape = 16
+label_text = "Mod website URL"
+input_placeholder = "https://example.com"
+hint_text = "URL for your website or repository."
+
+[node name="Dependencies" parent="TabContainer/Mod Manifest/ScrollContainer/VBox" instance=ExtResource( 3 )]
+unique_name_in_owner = true
+anchor_right = 0.0
+margin_top = 164.0
+margin_right = 1918.0
+margin_bottom = 188.0
+hint_tooltip = "Comma-separated list of mod IDs.
+Only letters, numbers and underscores allowed.
+A single dash in the middle is required.
+Format: {namespace}-{name}"
+mouse_default_cursor_shape = 16
+label_text = "Dependencies"
+input_placeholder = "Namespace-ModName, Author-Name"
+hint_text = "Comma-separated list of mod IDs.
+Only letters, numbers and underscores allowed.
+A single dash in the middle is required.
+Format: {namespace}-{name}"
+
+[node name="Description" parent="TabContainer/Mod Manifest/ScrollContainer/VBox" instance=ExtResource( 4 )]
+unique_name_in_owner = true
+anchor_right = 0.0
+margin_top = 192.0
+margin_right = 1918.0
+margin_bottom = 404.0
+label_text = "Description"
+
+[node name="Category2" type="LineEdit" parent="TabContainer/Mod Manifest/ScrollContainer/VBox"]
+margin_top = 408.0
+margin_right = 1918.0
+margin_bottom = 432.0
+mouse_filter = 2
+mouse_default_cursor_shape = 0
+text = "Godot Extra"
+align = 1
+editable = false
+context_menu_enabled = false
+virtual_keyboard_enabled = false
+shortcut_keys_enabled = false
+middle_mouse_paste_enabled = false
+
+[node name="Authors" parent="TabContainer/Mod Manifest/ScrollContainer/VBox" instance=ExtResource( 3 )]
+unique_name_in_owner = true
+anchor_right = 0.0
+margin_top = 436.0
+margin_right = 1918.0
+margin_bottom = 460.0
+hint_tooltip = "Comma-separated list of Authors"
+mouse_default_cursor_shape = 16
+label_text = "Authors"
+input_placeholder = "Author1, Autor2"
+hint_text = "Comma-separated list of Authors"
+
+[node name="Incompatibilities" parent="TabContainer/Mod Manifest/ScrollContainer/VBox" instance=ExtResource( 3 )]
+unique_name_in_owner = true
+anchor_right = 0.0
+margin_top = 464.0
+margin_right = 1918.0
+margin_bottom = 488.0
+hint_tooltip = "Comma-separated list of mod IDs.
+Only letters, numbers and underscores allowed.
+A single dash in the middle is required.
+Format: {namespace}-{name}"
+mouse_default_cursor_shape = 16
+label_text = "Incompatible Mods"
+input_placeholder = "Namespace-ModName, Author-Name"
+hint_text = "Comma-separated list of mod IDs.
+Only letters, numbers and underscores allowed.
+A single dash in the middle is required.
+Format: {namespace}-{name}"
+
+[node name="ComptatibleGameVersions" parent="TabContainer/Mod Manifest/ScrollContainer/VBox" instance=ExtResource( 3 )]
+unique_name_in_owner = true
+anchor_right = 0.0
+margin_top = 492.0
+margin_right = 1918.0
+margin_bottom = 516.0
+hint_tooltip = "Comma-separated list of valid game versions."
+mouse_default_cursor_shape = 16
+label_text = "Compatible Game Versions"
+input_placeholder = "1.0.0, 1.2.0"
+hint_text = "Comma-separated list of valid game versions."
+
+[node name="ComptatibleModLoaderVersions" parent="TabContainer/Mod Manifest/ScrollContainer/VBox" instance=ExtResource( 3 )]
+unique_name_in_owner = true
+anchor_right = 0.0
+margin_top = 520.0
+margin_right = 1918.0
+margin_bottom = 544.0
+hint_tooltip = "Comma-separated list of ModLoader versions."
+mouse_default_cursor_shape = 16
+label_text = "Compatible Mod Loader Versions"
+input_placeholder = "5.0.0, 4.1.0"
+hint_text = "Comma-separated list of ModLoader versions."
+
+[node name="Tags" parent="TabContainer/Mod Manifest/ScrollContainer/VBox" instance=ExtResource( 3 )]
+unique_name_in_owner = true
+anchor_right = 0.0
+margin_top = 548.0
+margin_right = 1918.0
+margin_bottom = 572.0
+hint_tooltip = "Compatible ModLoader Versions"
+mouse_default_cursor_shape = 16
+label_text = "Tags"
+input_placeholder = "Tag1, Tag2"
+hint_text = "Compatible ModLoader Versions"
+
 [node name="Default Configuration" type="PanelContainer" parent="TabContainer"]
 visible = false
-margin_right = 40.0
-margin_bottom = 24.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_left = 4.0
+margin_top = 24.0
+margin_right = -4.0
+margin_bottom = -4.0
 
-[connection signal="visibility_changed" from="." to="." method="_on_ModToolsDock_visibility_changed"]
+[connection signal="visibility_changed" from="." to="." method="_on_mod_tools_dock_visibility_changed"]
+[connection signal="pressed" from="TabContainer/Export/HSplit/Console/HBox/CopyOutput" to="." method="_on_copy_output_pressed"]
+[connection signal="pressed" from="TabContainer/Export/HSplit/Console/HBox/ClearOutput" to="." method="_on_clear_output_pressed"]
+[connection signal="pressed" from="TabContainer/Export/HSplit/Settings/Buttons/VBox/ExportAndRun" to="." method="_on_export_and_run_pressed"]
+[connection signal="pressed" from="TabContainer/Export/HSplit/Settings/Buttons/VBox/Export" to="." method="_on_export_pressed"]
+[connection signal="pressed" from="TabContainer/Export/HSplit/Settings/Buttons/VBox/ModSkeleton" to="." method="_on_mod_skeleton_pressed"]
+[connection signal="pressed" from="TabContainer/Mod Manifest/ScrollContainer/VBox/HBoxContainer/SaveManifest" to="." method="_on_save_manifest_pressed"]

--- a/godot-mod-export-tool-plugin/godot-3/addons/godot-mod-export/plugin.gd
+++ b/godot-mod-export-tool-plugin/godot-3/addons/godot-mod-export/plugin.gd
@@ -1,16 +1,18 @@
 tool
 extends EditorPlugin
 
-var dock
+var dock: Control
+
 
 func _enter_tree():
 	dock = preload("res://addons/godot-mod-export/dock.tscn").instance()
-	
+	dock.base_theme = get_editor_interface().get_base_control().theme
+
 	add_control_to_bottom_panel(dock, 'Mod Tools')
 
 
 func _exit_tree():
-	
+
 	remove_control_from_bottom_panel(dock)
-	
+
 	dock.free()


### PR DESCRIPTION
new manifest editor tab (doesn't do much yet)
made a new scene for these string inputs and changed the two from the export tab to those as well. you have to use `.get_value` now instead of getting the text from the input directly.
it also allows for some visual validation through ModManifest with `show_error_if_not(condition: bool)`

<img width="1006" alt="manifest" src="https://user-images.githubusercontent.com/51323316/219942131-4f7f9063-872d-496a-a69f-fcef32060fe2.png">
