### PR TITLE
remove attempted fix of godot bug

### DIFF
--- a/godot-mod-export-tool-plugin/godot-3/addons/godot-mod-export/input_string.gd
+++ b/godot-mod-export-tool-plugin/godot-3/addons/godot-mod-export/input_string.gd
@@ -50,14 +50,3 @@ func show_error_if_not(condition: bool) -> bool:
 	return condition
 
 
-
-func _on_Input_gui_input(event: InputEvent) -> void:
-	var input := ($"%Input" as TextEdit)
-
-	if event is InputEventPanGesture:
-		input.accept_event()
-
-	if event is InputEventMouseButton:
-		if event.button_index == BUTTON_WHEEL_UP or event.button_index == BUTTON_WHEEL_DOWN:
-			input.accept_event()
-

--- a/godot-mod-export-tool-plugin/godot-3/addons/godot-mod-export/input_string_multiline.tscn
+++ b/godot-mod-export-tool-plugin/godot-3/addons/godot-mod-export/input_string_multiline.tscn
@@ -40,5 +40,3 @@ size_flags_horizontal = 3
 show_line_numbers = true
 smooth_scrolling = true
 v_scroll_speed = 160.0
-
-[connection signal="gui_input" from="VSplit/Input" to="." method="_on_Input_gui_input"]


### PR DESCRIPTION
There is a bug in Godot where it incorrectly scrolls two nested scroll containers (scrollcontainer and textedit in this case) at the same time. There is no workaround, but we can just use the the textedit resize to "remove" the inner scroll in this case.